### PR TITLE
Test fixtures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+ETHERSCAN_API_KEY=
+
+# the deployer address, when using a ledger or a seed phrase
+SENDER_MAINNET=
+SENDER_GOERLI=
+
+# public rpc:
+RPC_MAINNET="https://rpc.ankr.com/eth"
+RPC_GOERLI="https://rpc.ankr.com/eth/goerli"

--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,2 @@
+EmptyTest_Unit:testTest() (gas: 120)
+EmptyTest_Fork:testTest() (gas: 6573)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: juice-contracts-template-tests
+name: juice-contracts-template-lint
 on:
   pull_request:
     branches:
@@ -41,14 +41,5 @@ jobs:
         uses: onbjerg/foundry-toolchain@v1
         with:
           version: nightly
-      - name: Install JS dependencies
-        if: |
-          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-          steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --prefer-offline
-      - name: install libraries
-        run: git submodule update --init
-      - name: Run tests
-        run: FOUNDRY_PROFILE=CI forge snapshot
-      - name: Check contract sizes
-        run: forge build --sizes
+      - name: Check linting
+        run: forge fmt --check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: juice-contracts-publish
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore cached yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Restore cached node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+            ./packages/hardhat/node_modules
+          key: ${{ runner.os }}-${{ steps.nvm.outputs.NVMRC }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.nvm.outputs.NVMRC }}-nodemodules-
+      - name: Install JS dependencies
+        if: |
+          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
+          steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --prefer-offline
+      # Publish deploy artifacts NPM packages. This will only run if there are new deploys.
+      - name: Publish NPM package
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: "public"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: juice-contracts-template-tests
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  forge-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore cached yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Restore cached node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+            ./packages/hardhat/node_modules
+          key: ${{ runner.os }}-${{ steps.nvm.outputs.NVMRC }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.nvm.outputs.NVMRC }}-nodemodules-
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Install JS dependencies
+        if: |
+          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
+          steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --prefer-offline
+      - name: install libraries
+        run: git submodule update --init
+      - name: Run tests
+        run: FOUNDRY_PROFILE=CI forge snapshot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,5 @@ jobs:
         run: git submodule update --init
       - name: Run tests
         run: FOUNDRY_PROFILE=CI forge snapshot
+      - name: Check contract sizes
+        run: forge build --sizes

--- a/README.md
+++ b/README.md
@@ -2,3 +2,34 @@
 Template used to code juicy solidity stuff - includes forge, libs, etc
 
 Install dependencies (forge tests, Juice-contracts-V3, OZ) via `forge install && yarn install`
+
+Use this template as a starting point, do not push straight on main, rather create a new branch and open a PR - your reviewer will love you for this.
+
+# Usage
+use `yarn test` to run tests
+
+use `yarn test:fork` to run tests in CI mode (including slower mainnet fork tests)
+
+<br>
+
+use `yarn size` to check contract size
+
+use `yarn doc` to generate natspec docs
+
+use `yarn lint` to lint the code
+
+use `yarn tree` to generate a Solidity dependency tree
+
+<br>
+
+use `yarn deploy:mainnet` and `yarn deploy:goerli` to deploy and verify (see .env.example for required env vars, using a ledger by default).
+
+## Code coverage
+Run `yarn coverage`to display code coverage summary and generate an LCOV report
+
+To display code coverage in VSCode:
+- You need to install the [coverage gutters extension (Ryan Luker)](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) or any other extension handling LCOV reports
+- ctrl shift p > "Coverage Gutters: Display Coverage" (coverage are the colored markdown lines in the left gutter, after the line numbers)
+
+## PR
+Github CI flow will run both unit and forked tests, log the contracts size (with the tests) and check linting compliance.

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,13 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+optimizer_runs = 200
+verbosity = 3 # display errors
+match_contract = "Unit" # only runs unit tests by default
+sizes = true
+
+[profile.CI] # run via FOUNDRY_PROFILE=CI foundry test
+fs_permissions = [{ access = "read", path = "./node_modules/@jbx-protocol/juice-contracts-v3/deployments/mainnet"}] # Get the deployment addresses for forking
+match_contract = "Unit || Fork" 
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -3,5 +3,16 @@
     "@jbx-protocol/juice-contracts-v3": "^2.0.3",
     "@openzeppelin/contracts": "^4.8.1",
     "@paulrberg/contracts": "^3.7.0"
+  },
+  "scripts": {
+    "test": "forge test",
+    "test:fork": "FOUNDRY_PROFILE=CI forge test",
+    "size": "forge build --sizes",
+    "coverage": "forge coverage --match-path ./src/*.sol --report lcov --report summary",
+    "doc": "forge doc",
+    "deploy:mainnet": "source .env && forge script DeployMainnet --broadcast --network mainnet --rpc-url $RPC_MAINNET --verify --ledger --sender $SENDER_MAINNET",
+    "deploy:goerli": "source .env && forge script DeployGoerli --broadcast --network mainnet --rpc-url $RPC_GOERLI --verify --ledger --sender $SENDER_GOERLI",
+    "tree": "forge tree",
+    "lint": "forge fmt"
   }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,7 +3,15 @@ pragma solidity ^0.8.17;
 
 import "forge-std/Script.sol";
 
-contract CounterScript is Script {
+contract DeployMainnet is Script {
+    function setUp() public {}
+
+    function run() public {
+        vm.broadcast();
+    }
+}
+
+contract DeployGoerli is Script {
     function setUp() public {}
 
     function run() public {

--- a/src/Empty.sol
+++ b/src/Empty.sol
@@ -2,4 +2,7 @@
 pragma solidity ^0.8.17;
 
 contract Empty {
+    constructor() {}
+
+    function empty() external {}
 }

--- a/test/Empty.t.sol
+++ b/test/Empty.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 import "forge-std/Test.sol";
 import "../src/Empty.sol";
 
-contract EmptyTest is Test {
+contract EmptyTest_Unit is Test {
 
     function setUp() public {
     }

--- a/test/Empty.t.sol
+++ b/test/Empty.t.sol
@@ -5,10 +5,9 @@ import "forge-std/Test.sol";
 import "../src/Empty.sol";
 
 contract EmptyTest_Unit is Test {
-
-    function setUp() public {
-    }
+    function setUp() public {}
 
     function testTest() public {
+        Empty empty = new Empty();
     }
 }

--- a/test/Fork.t.sol
+++ b/test/Fork.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBController.sol";
+import "@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBDirectory.sol";
+import "@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBFundingCycleStore.sol";
+import "@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol";
+import "@jbx-protocol/juice-contracts-v3/contracts/interfaces/IJBProjects.sol";
+
+import "../src/Empty.sol";
+
+contract EmptyTest_Fork is Test {
+    IJBController JBController;
+    IJBDirectory JBDirectory;
+    IJBFundingCycleStore JBFundingCycleStore;
+    IJBPayoutRedemptionPaymentTerminal JBEthTerminal;
+    IJBProjects JBProjects;
+
+    function setUp() public {
+        uint256 forkId = vm.createSelectFork("https://rpc.ankr.com/eth");
+
+        JBController = IJBController(
+            stdJson.readAddress(
+                vm.readFile("./node_modules/@jbx-protocol/juice-contracts-v3/deployments/mainnet/JBController.json"),
+                "address"
+            )
+        );
+
+        JBEthTerminal = IJBPayoutRedemptionPaymentTerminal(
+            stdJson.readAddress(
+                vm.readFile("./node_modules/@jbx-protocol/juice-contracts-v3/deployments/mainnet/JBETHPaymentTerminal.json"),
+                "address"
+            )
+        );
+
+        JBDirectory = JBController.directory();
+        JBFundingCycleStore = JBController.fundingCycleStore();
+        JBProjects = JBController.projects();
+    }
+
+    function testTest() public {
+        emit log_address(address(JBController.directory()));
+    }
+}

--- a/test/Fork.t.sol
+++ b/test/Fork.t.sol
@@ -18,8 +18,9 @@ contract EmptyTest_Fork is Test {
     IJBProjects JBProjects;
 
     function setUp() public {
-        uint256 forkId = vm.createSelectFork("https://rpc.ankr.com/eth");
-
+        uint256 forkId = vm.createSelectFork("https://rpc.ankr.com/eth"); // Will start on latest block by default
+        
+        // Collect the mainnet deployment addresses
         JBController = IJBController(
             stdJson.readAddress(
                 vm.readFile("./node_modules/@jbx-protocol/juice-contracts-v3/deployments/mainnet/JBController.json"),

--- a/test/Fork.t.sol
+++ b/test/Fork.t.sol
@@ -18,8 +18,8 @@ contract EmptyTest_Fork is Test {
     IJBProjects JBProjects;
 
     function setUp() public {
-        uint256 forkId = vm.createSelectFork("https://rpc.ankr.com/eth"); // Will start on latest block by default
-        
+        vm.createSelectFork("https://rpc.ankr.com/eth"); // Will start on latest block by default
+
         // Collect the mainnet deployment addresses
         JBController = IJBController(
             stdJson.readAddress(
@@ -30,7 +30,9 @@ contract EmptyTest_Fork is Test {
 
         JBEthTerminal = IJBPayoutRedemptionPaymentTerminal(
             stdJson.readAddress(
-                vm.readFile("./node_modules/@jbx-protocol/juice-contracts-v3/deployments/mainnet/JBETHPaymentTerminal.json"),
+                vm.readFile(
+                    "./node_modules/@jbx-protocol/juice-contracts-v3/deployments/mainnet/JBETHPaymentTerminal.json"
+                ),
                 "address"
             )
         );


### PR DESCRIPTION
# Description

Add tests and yarn commands to the template

## Limitations & risks

- Adding usefull tooling without adding too much constraints is a really thin equilibrium, this might be too constrained.
- There is no formal verification template (yet), juicebox V3 invariant should still be defined and included in an SMTChecker fixture

# Check-list
don't need to edit the [ ], you can tick them later + you see the status in the PR listing
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
contract template repo
- Indirectly:
future contracts built from this template