### PR TITLE
Remappings >toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 .vscode
 cache/
+out/
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,21 @@
-.env
+# Local config
 .vscode
+.DS_Store
+
+# Dotenv file
+.env
+
+# Dependencies
+node_modules/
+
+# Compiler files
 cache/
 out/
-node_modules/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Logs
+yarn-error.log

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 src = 'src'
 out = 'out'
-libs = ['lib']
+libs = ['lib', 'node_modules']
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,0 @@
-@jbx-protocol/=node_modules/@jbx-protocol/
-@openzeppelin/=node_modules/@openzeppelin/
-@paulrberg/=node_modules/@paulrberg/
-prb-math/=node_modules/prb-math/
-ds-test/=lib/ds-test/src/
-forge-std/=lib/forge-std/src/


### PR DESCRIPTION
# Description

1. Improves the `.gitignore`
2. Removes `remappings.txt` in favor of adding `node_modules` to the `foundry.toml`'s `libs`.

## Limitations & risks

Could introduce a problem with regard to dependency management.

# Check-list
- [n/a] Tests are covering the new feature
- [n/a] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [n/a] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [i am a noob and i dont know how to do this] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- none