### PR TITLE
Add `preinstall` script to run `forge install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # juice-contract-template
 Template used to code juicy solidity stuff - includes forge, libs, etc
 
-Install dependencies (forge tests, Juice-contracts-V3, OZ) via `forge install && yarn install`
+Install dependencies (forge tests, Juice-contracts-V3, OZ) via `yarn install` (the `preinstall` script will run `forge install` for you)
 
 Use this template as a starting point, do not push straight on main, rather create a new branch and open a PR - your reviewer will love you for this.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@paulrberg/contracts": "^3.7.0"
   },
   "scripts": {
+    "preinstall": "forge install",
     "test": "forge test",
     "test:fork": "FOUNDRY_PROFILE=CI forge test",
     "size": "forge build --sizes",


### PR DESCRIPTION
# Description

Add `preinstall` script to run `forge install`. Instead of having to run `forge install && yarn install`, you will be able to run `yarn`.

## Limitations & risks

There may be situations where somebody wants to install yarn dependencies but not forge dependencies.